### PR TITLE
更改了BOSS等待时对BOSS名称识别的逻辑，现在至少识别2字符才会进行判断是否等待。

### DIFF
--- a/background/utils.py
+++ b/background/utils.py
@@ -802,7 +802,7 @@ def boss_wait(bossName):
     keywords_robot = ["聚", "械", "机", "偶"]
 
     def contains_any_combinations(name, keywords):
-        for r in range(1, len(keywords) + 1):
+        for r in range(2, len(keywords) + 1):
             for comb in itertools.combinations(keywords, r):
                 if all(word in name for word in comb):
                     return True


### PR DESCRIPTION
此问题曾导致所有带"之"的BOSS都会进行和龟龟一样的16秒等待。