### PR TITLE
修复声骸合成时Cost1主词条识别失败,无法锁定问题

### DIFF
--- a/background/utils.py
+++ b/background/utils.py
@@ -1159,7 +1159,7 @@ def echo_synthesis():
                     time.sleep(0.02)
                 time.sleep(0.8)
                 random_click(1000, 685)
-        region = set_region(830, 440, 1250, 470)
+        region = set_region(830, 440, 1250, 485)
         cost_mapping = {
             "1": (echo.echoCost1MainStatus, 1),
             "3": (echo.echoCost3MainStatus, 1),


### PR DESCRIPTION
#165 #155 修复声骸合成时Cost1主词条识别失败,无法锁定问题

问题复现截图：
![bug_before_fix1](https://github.com/lazydog28/mc_auto_boss/assets/27144246/9129204c-f6a6-4778-af4c-28458a54bf35)
![bug_before_fix2](https://github.com/lazydog28/mc_auto_boss/assets/27144246/fed938e5-6037-411e-a663-06abe50b0e7a)

问题原因：
排查后发现，截图裁剪后的的OCR，未正确识别主词条。

修复方法：
调整截图的裁剪区域的高度

修复结果截图：
![bug_after_fix1](https://github.com/lazydog28/mc_auto_boss/assets/27144246/1f0f5be5-01eb-4a54-8849-4d38d8d60c4b)
![bug_after_fix2](https://github.com/lazydog28/mc_auto_boss/assets/27144246/2536c0c6-fd94-4c2f-be9b-2b0f1a2e242c)
