### PR TITLE
改善非N卡用户的运行速度，允许YOLO调用GPU运算

### DIFF
--- a/background/ocr.py
+++ b/background/ocr.py
@@ -5,6 +5,7 @@
 @time: 2024/6/5 下午4:36
 @author SuperLazyDog
 """
+import os
 import time
 import paddle
 from paddleocr import PaddleOCR
@@ -24,6 +25,7 @@ if paddle.is_compiled_with_cuda() and paddle.get_device().startswith(
     use_gpu = True
 else:
     use_gpu = False
+    os.environ['FLAGS_use_mkldnn'] = '1'  # CPU启用mkldnn加速
 
 if current_process().name == "task":
     logger("OCR初始化中...")

--- a/background/yolo.py
+++ b/background/yolo.py
@@ -15,9 +15,11 @@ from multiprocessing import current_process
 
 
 model_path = os.path.join(root_path, "models/" + config.ModelName + ".onnx")
-# 判断能否使用GPU
+# 判断能否使用GPU或Dml
 if "CUDAExecutionProvider" in rt.get_available_providers():
     provider = ["CUDAExecutionProvider"]
+elif "DmlExecutionProvider" in rt.get_available_providers():
+    provider = ["DmlExecutionProvider"]
 else:
     provider = ["CPUExecutionProvider"]
 

--- a/requirements_dml.txt
+++ b/requirements_dml.txt
@@ -1,0 +1,16 @@
+pynput
+opencv-python
+pywin32
+pillow
+numpy==1.26.4
+setuptools
+pyyaml
+pydantic
+onnxruntime
+onnxruntime-directml
+paddlepaddle
+paddleocr<2.8.0
+colorama
+requests
+pyautogui
+psutil


### PR DESCRIPTION
非N卡用户yolo启用GPU_dml加速，OCR的cpu识别启用mkldnn加速
dml版requirements_dml.txt直接pip安装就行
支持DX12的显卡都可以使用，包括N卡在内，不过N卡还是CUDA运算更快，不推荐N卡更换dml使用

已测试成功调用GPU的显卡：
rx580
7900xt
6800xt