### PR TITLE
修复误判副本结束，导致人物长时间站立不动的bug

### DIFF
--- a/background/task/pages/dreamless.py
+++ b/background/task/pages/dreamless.py
@@ -217,7 +217,7 @@ def confirm_leave_action(positions: dict[str, Position]) -> bool:
     :return:
     """
     click_position(positions["确认"])
-    time.sleep(0.5)
+    time.sleep(3)
     wait_home()
     logger(f"{info.lastBossName}副本结束")
     time.sleep(2)

--- a/background/utils.py
+++ b/background/utils.py
@@ -636,6 +636,7 @@ def wait_home(timeout=120) -> bool:
             raise Exception("等待回到主界面超时")
         img = screenshot()
         if img is None:
+            time.sleep(0.3)
             continue
         results = ocr(img)
         if search_text(results, "特征码"):  # 特征码
@@ -650,6 +651,7 @@ def wait_home(timeout=120) -> bool:
         template = np.array(template)
         if match_template(img, template, threshold=0.9):
             return True
+        time.sleep(0.3)
 
 
 def turn_to_search() -> int | None:


### PR DESCRIPTION
原流程是：
弹出确认离开框 -》点确认 -》弹框消失**恢复战斗主界面** -》游戏进入加载画面 -》程序判断是否回到主界面
bug流程：
弹出确认离开框 -》点确认 -》弹框消失**恢复战斗主界面**  -》**程序判断是否在主界面** -》游戏进入加载画面 -》但程序误判已回到主界面，导致人物站着不动

此bug由PR[#234]引入，还修改了多处时间，我没有测试这些是否有问题，望up重审此PR