### PR TITLE
监测UE4-Client Game已崩溃弹窗，发现就关闭弹窗，干掉游戏进程

### DIFF
--- a/background/hwnd_util.py
+++ b/background/hwnd_util.py
@@ -29,6 +29,9 @@ official_login_hwnd_title = ""
 # b服登录窗口
 bilibili_login_hwnd_class_name = "CLoginDlg_P_8340_\\d{10}"  # CLoginDlg_P_8340_1720374432
 bilibili_login_hwnd_title = "bilibili游戏 登录_弹框"
+# UE4-Client崩溃窗口
+ue4_client_hwnd_class_name = "#32770"
+ue4_client_hwnd_title = "UE4-Client Game已崩溃，即将关闭"
 
 
 def get_pid_by_exe_name(exe_name: str):
@@ -105,3 +108,14 @@ def get_login_hwnd_bilibili():
             # print(f"window class: {window_class}, title: {win32gui.GetWindowText(wd_hwnd)}")
             return wd_hwnd
     return None
+
+
+# UE4-Client Game已崩溃窗口句柄 by wakening
+def get_ue4_client_crash_hwnd():
+    windows_list: list = get_all_hwnd()
+    for wd_hwnd in windows_list:
+        title = win32gui.GetWindowText(wd_hwnd)
+        if title is not None and title == ue4_client_hwnd_title:
+            return wd_hwnd
+    return None
+

--- a/background/main.py
+++ b/background/main.py
@@ -164,17 +164,24 @@ def run(task: Task, e: Event):
 
     logger("卡加载监测启动")
     anti_stuck_list = []
-    last_timestamp = int(time.time())
+    last_anti_stuck_timestamp = int(time.time())
+    logger("UE4崩溃监测启动")
+    last_check_ue4_timestamp = int(time.time())
 
     while e.is_set():
+        # 监测UE4-Client Game已崩溃弹窗，发现就关闭弹窗，干掉游戏进程
+        check_timestamp = ue4_client_crash_monitor(last_check_ue4_timestamp)
+        if check_timestamp is not None:
+            last_check_ue4_timestamp = check_timestamp
+
         img = screenshot()
         result = ocr(img)
         task(img, result)
 
         # 监测游戏是否卡加载，长时间卡在加载界面就干掉游戏进程
-        check_timestamp = anti_stuck_monitor(img, anti_stuck_list, last_timestamp)
+        check_timestamp = anti_stuck_monitor(img, anti_stuck_list, last_anti_stuck_timestamp)
         if check_timestamp is not None:
-            last_timestamp = check_timestamp
+            last_anti_stuck_timestamp = check_timestamp
     logger("进程停止运行")
 
 


### PR DESCRIPTION
刚好碰到了，可遇不可求，优化一下，每分钟检测一次，轻量高效
![屏幕截图 2024-07-18 114647](https://github.com/user-attachments/assets/e1ce0128-6088-4e94-901f-d9e61a8f1579)
之前的逻辑十分不合理，可考虑移除
https://github.com/lazydog28/mc_auto_boss/blob/gpu/background/main.py#L296-L299